### PR TITLE
Use global basis for character movement

### DIFF
--- a/addons/PlayerCharacter/StateMachine/CrouchStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/CrouchStateScript.gd
@@ -65,7 +65,7 @@ func inputManagement():
 			
 func move(delta : float):
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	if cR.moveDirection and cR.is_on_floor():
 		cR.velocity.x = lerp(cR.velocity.x, cR.moveDirection.x * cR.moveSpeed, cR.moveAccel * delta)

--- a/addons/PlayerCharacter/StateMachine/IdleStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/IdleStateScript.gd
@@ -66,7 +66,7 @@ func move(delta : float):
 	#direction input
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
 	#get the move direction depending on the input
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	if cR.moveDirection and cR.is_on_floor():
 		#transition to corresponding state

--- a/addons/PlayerCharacter/StateMachine/InairStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/InairStateScript.gd
@@ -56,7 +56,7 @@ func checkIfFloor():
 		
 func move(delta : float):
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	if !cR.is_on_floor():
 		if cR.moveDirection:

--- a/addons/PlayerCharacter/StateMachine/JumpStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/JumpStateScript.gd
@@ -51,7 +51,7 @@ func checkIfFloor():
 		
 func move(delta : float):
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	#move only apply when the character is not on the floor (so if he's in the air)
 	if !cR.is_on_floor():

--- a/addons/PlayerCharacter/StateMachine/RunStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/RunStateScript.gd
@@ -71,7 +71,7 @@ func inputManagement():
 		
 func move(delta : float):
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	if cR.moveDirection and cR.is_on_floor():
 		cR.velocity.x = lerp(cR.velocity.x, cR.moveDirection.x * cR.moveSpeed, cR.moveAccel * delta)

--- a/addons/PlayerCharacter/StateMachine/WalkStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/WalkStateScript.gd
@@ -65,7 +65,7 @@ func inputManagement():
 		
 func move(delta : float):
 	cR.inputDirection = Input.get_vector(cR.moveLeftAction, cR.moveRightAction, cR.moveForwardAction, cR.moveBackwardAction)
-	cR.moveDirection = (cR.camHolder.basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
+	cR.moveDirection = (cR.camHolder.global_basis * Vector3(cR.inputDirection.x, 0.0, cR.inputDirection.y)).normalized()
 	
 	if cR.moveDirection and cR.is_on_floor():
 		#apply smooth move


### PR DESCRIPTION
If you drop `PlayerCharacterScene` into your own scene and rotate it, the movement controls are off. I think this is because of the usage of the local `basis` in movement state scripts. To mitigate it, this PR changes `cR.camHolder.basis` to `cR.camHolder.global_basis`.