### PR TITLE
fix: prevent hop acceleration from exceeding max speed limit

### DIFF
--- a/addons/PlayerCharacter/StateMachine/JumpStateScript.gd
+++ b/addons/PlayerCharacter/StateMachine/JumpStateScript.gd
@@ -62,6 +62,9 @@ func move(delta : float):
 			
 			cR.velocity.x = lerp(cR.velocity.x, cR.moveDirection.x * contrdDesMoveSpeed, contrdInAirMoveSpeed * delta)
 			cR.velocity.z = lerp(cR.velocity.z, cR.moveDirection.z * contrdDesMoveSpeed, contrdInAirMoveSpeed * delta)
+
+			if cR.velocity.length() > cR.maxSpeed:
+				cR.velocity = cR.velocity.normalized() * cR.maxSpeed
 		else:
 			#accumulate desired speed for bunny hopping
 			cR.desiredMoveSpeed = cR.velocity.length()


### PR DESCRIPTION
Character velocity reaches beyond max speed limit when hopping repeatedly. This fix prevents that.